### PR TITLE
Log analytics changes

### DIFF
--- a/config/custom-parameters/alzDefaultPolicyAssignments.parameters.all.json
+++ b/config/custom-parameters/alzDefaultPolicyAssignments.parameters.all.json
@@ -12,7 +12,7 @@
       "value": ""
     },
     "parDdosEnabled": {
-      "value": true
+      "value": false
     },
     "parPlatformMgAlzDefaultsEnable": {
       "value": true
@@ -30,7 +30,7 @@
       "value": "/subscriptions/8eb96836-cced-45a1-8949-ce2596c96523/resourcegroups/rg-alz-logging/providers/microsoft.operationalinsights/workspaces/alz-log-analytics"
     },
     "parLogAnalyticsWorkspaceLogRetentionInDays": {
-      "value": "365"
+      "value": "30"
     },
     "parLogAnalyticsWorkspaceResourceCategory": {
       "value": "allLogs"

--- a/config/custom-parameters/hubNetworking.parameters.all.json
+++ b/config/custom-parameters/hubNetworking.parameters.all.json
@@ -55,13 +55,13 @@
       "value": "-PublicIP"
     },
     "parAzBastionEnabled": {
-      "value": true
+      "value": false
     },
     "parAzBastionName": {
       "value": "alz-bastion-swedencentral"
     },
     "parAzBastionSku": {
-      "value": "Standard"
+      "value": "Basic"
     },
     "parAzBastionTunneling": {
       "value": false
@@ -70,13 +70,13 @@
       "value": "nsg-AzureBastionSubnet-swedencentral"
     },
     "parDdosEnabled": {
-      "value": true
+      "value": false
     },
     "parDdosPlanName": {
       "value": "alz-ddos-plan-swedencentral"
     },
     "parAzFirewallEnabled": {
-      "value": true
+      "value": false
     },
     "parAzFirewallName": {
       "value": "alz-azfw-swedencentral"
@@ -112,7 +112,7 @@
       ]
     },
     "parAzFirewallDnsProxyEnabled": {
-      "value": true
+      "value": false
     },
     "parAzFirewallDnsServers": {
       "value": []
@@ -124,59 +124,22 @@
       "value": false
     },
     "parPrivateDnsZonesEnabled": {
-      "value": true
+      "value": false
     },
     "parPrivateDnsZones": {
       "value": []
     },
     "parVpnGatewayEnabled": {
-      "value": true
+      "value": false
     },
     "parVpnGatewayConfig": {
-      "value": {
-        "name": "alz-Vpn-Gateway",
-        "gatewayType": "Vpn",
-        "sku": "VpnGw1AZ",
-        "vpnType": "RouteBased",
-        "generation": "Generation1",
-        "enableBgp": false,
-        "activeActive": false,
-        "enableBgpRouteTranslationForNat": false,
-        "enableDnsForwarding": false,
-        "bgpPeeringAddress": "",
-        "bgpsettings": {
-          "asn": "65515",
-          "bgpPeeringAddress": "",
-          "peerWeight": "5"
-        },
-        "vpnClientConfiguration": {},
-        "ipConfigurationName": "vnetGatewayConfig",
-        "ipConfigurationActiveActiveName": "vnetGatewayConfig2"
-      }
+      "value": {}
     },
     "parExpressRouteGatewayEnabled": {
-      "value": true
+      "value": false
     },
     "parExpressRouteGatewayConfig": {
-      "value": {
-        "name": "alz-ExpressRoute-Gateway",
-        "gatewayType": "ExpressRoute",
-        "sku": "ErGw1Az",
-        "vpnType": "RouteBased",
-        "generation": "None",
-        "enableBgp": false,
-        "activeActive": false,
-        "enableBgpRouteTranslationForNat": false,
-        "enableDnsForwarding": false,
-        "bgpPeeringAddress": "",
-        "bgpsettings": {
-          "asn": "65515",
-          "bgpPeeringAddress": "",
-          "peerWeight": "5"
-        },
-        "ipConfigurationName": "vnetGatewayConfig",
-        "ipConfigurationActiveActiveName": "vnetGatewayConfig2"
-      }
+      "value": {}
     },
     "parTags": {
       "value": {

--- a/config/custom-parameters/hubNetworking.parameters.multiRegion.all.json
+++ b/config/custom-parameters/hubNetworking.parameters.multiRegion.all.json
@@ -98,7 +98,7 @@
       "value": "-PublicIP"
     },
     "parAzBastionEnabled": {
-      "value": true
+      "value": false
     },
     "parAzBastionEnabledSecondaryLocation": {
       "value": false
@@ -110,10 +110,10 @@
       "value": "alz-bastion-"
     },
     "parAzBastionSku": {
-      "value": "Standard"
+      "value": "Basic"
     },
     "parAzBastionSkuSecondaryLocation": {
-      "value": "Standard"
+      "value": "Basic"
     },
     "parAzBastionTunneling": {
       "value": false
@@ -128,19 +128,19 @@
       "value": "nsg-AzureBastionSubnet-"
     },
     "parDdosEnabled": {
-      "value": true
+      "value": false
     },
     "parDdosPlanName": {
       "value": "alz-ddos-plan-swedencentral"
     },
     "parDdosEnabledSecondaryLocation": {
-      "value": true
+      "value": false
     },
     "parDdosPlanNameSecondaryLocation": {
       "value": "alz-ddos-plan-"
     },
     "parAzFirewallEnabled": {
-      "value": true
+      "value": false
     },
     "parAzFirewallName": {
       "value": "alz-azfw-swedencentral"
@@ -162,7 +162,7 @@
       ]
     },
     "parAzFirewallEnabledSecondaryLocation": {
-      "value": true
+      "value": false
     },
     "parAzFirewallNameSecondaryLocation": {
       "value": "alz-azfw-"
@@ -200,7 +200,7 @@
       "value": []
     },
     "parAzFirewallDnsProxyEnabled": {
-      "value": true
+      "value": false
     },
     "parAzFirewallDnsServers": {
       "value": []
@@ -212,7 +212,7 @@
       "value": false
     },
     "parAzFirewallDnsProxyEnabledSecondaryLocation": {
-      "value": true
+      "value": false
     },
     "parAzFirewallDnsServersSecondaryLocation": {
       "value": []
@@ -224,106 +224,34 @@
       "value": false
     },
     "parPrivateDnsZonesEnabled": {
-      "value": true
+      "value": false
     },
     "parPrivateDnsZones": {
       "value": []
     },
     "parVpnGatewayEnabled": {
-      "value": true
+      "value": false
     },
     "parVpnGatewayEnabledSecondaryLocation": {
-      "value": true
+      "value": false
     },
     "parVpnGatewayConfig": {
-      "value": {
-        "name": "alz-vpn-gateway",
-        "gatewayType": "Vpn",
-        "sku": "VpnGw1AZ",
-        "vpnType": "RouteBased",
-        "generation": "Generation1",
-        "enableBgp": false,
-        "activeActive": false,
-        "enableBgpRouteTranslationForNat": false,
-        "enableDnsForwarding": false,
-        "bgpPeeringAddress": "",
-        "bgpsettings": {
-          "asn": "65515",
-          "bgpPeeringAddress": "",
-          "peerWeight": "5"
-        },
-        "vpnClientConfiguration": {},
-        "ipConfigurationName": "vnetGatewayConfig",
-        "ipConfigurationActiveActiveName": "vnetGatewayConfig2"
-      }
+      "value": {}
     },
     "parVpnGatewayConfigSecondaryLocation": {
-      "value": {
-        "name": "alz-vpn-gateway-secondary",
-        "gatewayType": "Vpn",
-        "sku": "VpnGw1AZ",
-        "vpnType": "RouteBased",
-        "generation": "Generation1",
-        "enableBgp": false,
-        "activeActive": false,
-        "enableBgpRouteTranslationForNat": false,
-        "enableDnsForwarding": false,
-        "bgpPeeringAddress": "",
-        "bgpsettings": {
-          "asn": "65515",
-          "bgpPeeringAddress": "",
-          "peerWeight": "5"
-        },
-        "vpnClientConfiguration": {},
-        "ipConfigurationName": "vnetGatewayConfig",
-        "ipConfigurationActiveActiveName": "vnetGatewayConfig2"
-      }
+      "value": {}
     },
     "parExpressRouteGatewayEnabled": {
-      "value": true
+      "value": false
     },
     "parExpressRouteGatewayConfig": {
-      "value": {
-        "name": "alz-expressroute-gateway",
-        "gatewayType": "ExpressRoute",
-        "sku": "ErGw1Az",
-        "vpnType": "RouteBased",
-        "generation": "None",
-        "enableBgp": false,
-        "activeActive": false,
-        "enableBgpRouteTranslationForNat": false,
-        "enableDnsForwarding": false,
-        "bgpPeeringAddress": "",
-        "bgpsettings": {
-          "asn": "65515",
-          "bgpPeeringAddress": "",
-          "peerWeight": "5"
-        },
-        "ipConfigurationName": "vnetGatewayConfig",
-        "ipConfigurationActiveActiveName": "vnetGatewayConfig2"
-      }
+      "value": {}
     },
     "parExpressRouteGatewayEnabledSecondaryLocation": {
-      "value": true
+      "value": false
     },
     "parExpressRouteGatewayConfigSecondaryLocation": {
-      "value": {
-        "name": "alz-expressroute-gateway-secondary",
-        "gatewayType": "ExpressRoute",
-        "sku": "ErGw1Az",
-        "vpnType": "RouteBased",
-        "generation": "None",
-        "enableBgp": false,
-        "activeActive": false,
-        "enableBgpRouteTranslationForNat": false,
-        "enableDnsForwarding": false,
-        "bgpPeeringAddress": "",
-        "bgpsettings": {
-          "asn": "65515",
-          "bgpPeeringAddress": "",
-          "peerWeight": "5"
-        }
-      }
+      "value": {}
     },
     "parTags": {
       "value": {

--- a/config/custom-parameters/logging.parameters.all.json
+++ b/config/custom-parameters/logging.parameters.all.json
@@ -9,18 +9,16 @@
       "value": "swedencentral"
     },
     "parLogAnalyticsWorkspaceSkuName": {
-      "value": "PerGB2018"
+      "value": "Free"
     },
     "parLogAnalyticsWorkspaceCapacityReservationLevel": {
-      "value": 100
+      "value": 0
     },
     "parLogAnalyticsWorkspaceLogRetentionInDays": {
-      "value": 365
+      "value": 30
     },
     "parLogAnalyticsWorkspaceSolutions": {
-      "value": [
-        "SecurityInsights"
-      ]
+      "value": []
     },
     "parDataCollectionRuleVMInsightsName": {
       "value": "alz-ama-vmi-dcr"

--- a/config/custom-parameters/logging.parameters.all.json
+++ b/config/custom-parameters/logging.parameters.all.json
@@ -12,7 +12,7 @@
       "value": "Free"
     },
     "parLogAnalyticsWorkspaceCapacityReservationLevel": {
-      "value": 0
+      "value": 100
     },
     "parLogAnalyticsWorkspaceLogRetentionInDays": {
       "value": 30

--- a/config/custom-parameters/vwanConnectivity.parameters.all.json
+++ b/config/custom-parameters/vwanConnectivity.parameters.all.json
@@ -9,7 +9,7 @@
       "value": "alz"
     },
     "parVirtualHubEnabled": {
-      "value": true
+      "value": false
     },
     "parVirtualWanName": {
       "value": "alz-vwan-swedencentral"
@@ -38,9 +38,9 @@
     "parVirtualWanHubs": {
       "value": [
         {
-          "parVpnGatewayEnabled": true,
-          "parExpressRouteGatewayEnabled": true,
-          "parAzFirewallEnabled": true,
+          "parVpnGatewayEnabled": false,
+          "parExpressRouteGatewayEnabled": false,
+          "parAzFirewallEnabled": false,
           "parVirtualHubAddressPrefix": "10.100.0.0/23",
           "parHubLocation": "swedencentral",
           "parHubRoutingPreference": "ExpressRoute",
@@ -48,7 +48,7 @@
           "parVirtualHubRoutingIntentDestinations": [],
           "parAzFirewallDnsServers": [],
           "parAzFirewallIntelMode": "Alert",
-          "parAzFirewallDnsProxyEnabled": true,
+          "parAzFirewallDnsProxyEnabled": false,
           "parAzFirewallTier": "Standard",
           "parAzFirewallAvailabilityZones": [
             "1",
@@ -65,13 +65,13 @@
       "value": 1
     },
     "parDdosEnabled": {
-      "value": true
+      "value": false
     },
     "parDdosPlanName": {
       "value": "alz-ddos-plan-swedencentral"
     },
     "parPrivateDnsZonesEnabled": {
-      "value": true
+      "value": false
     },
     "parPrivateDnsZones": {
       "value": []

--- a/config/custom-parameters/vwanConnectivity.parameters.multiRegion.all.json
+++ b/config/custom-parameters/vwanConnectivity.parameters.multiRegion.all.json
@@ -9,7 +9,7 @@
       "value": "alz"
     },
     "parVirtualHubEnabled": {
-      "value": true
+      "value": false
     },
     "parVirtualWanName": {
       "value": "alz-vwan-swedencentral"
@@ -41,9 +41,9 @@
     "parVirtualWanHubs": {
       "value": [
         {
-          "parVpnGatewayEnabled": true,
-          "parExpressRouteGatewayEnabled": true,
-          "parAzFirewallEnabled": true,
+          "parVpnGatewayEnabled": false,
+          "parExpressRouteGatewayEnabled": false,
+          "parAzFirewallEnabled": false,
           "parVirtualHubAddressPrefix": "10.100.0.0/23",
           "parHubLocation": "swedencentral",
           "parHubRoutingPreference": "ExpressRoute",
@@ -51,7 +51,7 @@
           "parVirtualHubRoutingIntentDestinations": [],
           "parAzFirewallDnsServers": [],
           "parAzFirewallIntelMode": "Alert",
-          "parAzFirewallDnsProxyEnabled": true,
+          "parAzFirewallDnsProxyEnabled": false,
           "parAzFirewallTier": "Standard",
           "parAzFirewallAvailabilityZones": [
             "1",
@@ -60,9 +60,9 @@
           ]
         },
         {
-          "parVpnGatewayEnabled": true,
-          "parExpressRouteGatewayEnabled": true,
-          "parAzFirewallEnabled": true,
+          "parVpnGatewayEnabled": false,
+          "parExpressRouteGatewayEnabled": false,
+          "parAzFirewallEnabled": false,
           "parVirtualHubAddressPrefix": "10.200.0.0/23",
           "parHubLocation": "",
           "parHubRoutingPreference": "ExpressRoute",
@@ -70,7 +70,7 @@
           "parVirtualHubRoutingIntentDestinations": [],
           "parAzFirewallDnsServers": [],
           "parAzFirewallIntelMode": "Alert",
-          "parAzFirewallDnsProxyEnabled": true,
+          "parAzFirewallDnsProxyEnabled": false,
           "parAzFirewallTier": "Standard",
           "parAzFirewallAvailabilityZones": [
             "1",
@@ -87,13 +87,13 @@
       "value": 1
     },
     "parDdosEnabled": {
-      "value": true
+      "value": false
     },
     "parDdosPlanName": {
       "value": "alz-ddos-plan-swedencentral"
     },
     "parPrivateDnsZonesEnabled": {
-      "value": true
+      "value": false
     },
     "parPrivateDnsZones": {
       "value": []


### PR DESCRIPTION
Updated the parLogAnalyticsWorkspaceCapacityReservationLevel parameter value from 0 to 100 to comply with ARM template validation requirements. Although this parameter is only applicable when parLogAnalyticsWorkspaceSkuName is set to "CapacityReservation", the template does not accept 0 as a valid input—even when unused.

Setting it to 100, the minimum valid reservation tier, ensures successful deployment without impacting the actual configuration, since CapacityReservation SKU is not being used.